### PR TITLE
Fix for wrong mapfile names during the demo upload

### DIFF
--- a/functions/logs/getdemos.js
+++ b/functions/logs/getdemos.js
@@ -10,7 +10,6 @@ let d = new Date();
 let { getLastMatch } = require('../match/matchFunctions');
 
 
-// Función para obtener el tamaño de un archivo en bytes
 async function getFileSize(filename) {
     return statAsync(filename).then((stats) => stats.size);
 }
@@ -25,7 +24,6 @@ function getLastPickup(){
     }
 }
 
-//Extrae el nombre del mapa del nombre de un archivo .dem
 function clipMapName(filename) {
     const regex = /LATAM-\d+-([\w-]+)\.dem/;
     const match = filename.match(regex);
@@ -35,7 +33,6 @@ function clipMapName(filename) {
     return null;
   }
 
-// Función para comprimir los archivos que pesan más de 10 MB
 async function getDemos() {
     return readdirAsync(demosFullPath)
         .then((files) => {
@@ -56,16 +53,14 @@ async function getDemos() {
                     const lastMapName = clipMapName(lastMapFile.filePath.split('/').pop());
 
                     let demosZipPath = Path.resolve(demosZippedFullpath +`/${d.getFullYear()}-${d.getMonth()}-${d.getDate()}-${d.getHours()}-${d.getMinutes()}-${lastMapName ?? "tfcmap"}.zip`);
-                    // Crea un flujo de escritura para el archivo comprimido
                     const writeStream = fs.createWriteStream(demosZipPath);
 
                     const archive = archiver('zip', {
-                        zlib: { level: 9 } // Nivel de compresión máximo (mejor calidad, más lento)
+                        zlib: { level: 9 } 
                       });
 
                     archive.pipe(writeStream);
 
-                    // Pipe los flujos de lectura de los archivos al flujo de compresión y luego al flujo de escritura
                     let lastTwoFiles = []
                     lastTwoFiles.push(filesToCompressFiltered.pop())
                     lastTwoFiles.push(filesToCompressFiltered.pop())
@@ -78,12 +73,10 @@ async function getDemos() {
                     
 
                     return new Promise((resolve, reject) => {
-                        // Adjunta un evento 'finish' para indicar que el proceso ha terminado
                         writeStream.on('finish', () => {
                             resolve('Files zipped correctly.');
                         });
 
-                        // Manejo de errores durante la compresión
                         writeStream.on('error', (err) => {
                             reject(err);
                         });

--- a/functions/logs/getdemos.js
+++ b/functions/logs/getdemos.js
@@ -26,9 +26,9 @@ function getLastPickup(){
 }
 
 //Extrae el nombre del mapa del nombre de un archivo .dem
-function extraerNombreDeMapa(nombrearchivo) {
+function clipMapName(filename) {
     const regex = /LATAM-\d+-([\w-]+)\.dem/;
-    const match = nombrearchivo.match(regex);
+    const match = filename.match(regex);
     if (match) {
       return match[1];
     }
@@ -52,10 +52,10 @@ async function getDemos() {
                     if (filesToCompressFiltered.length === 0) {
                         throw new Error('There were no files beyond 10MB Size.');
                     }
-                    const ultimoMapaArchivo = filesToCompressFiltered[filesToCompressFiltered.length -1];
-                    const ultimoMapaNombre = extraerNombreDeMapa(ultimoMapaArchivo.filePath.split('/').pop());
+                    const lastMapFile = filesToCompressFiltered[filesToCompressFiltered.length -1];
+                    const lastMapName = clipMapName(lastMapFile.filePath.split('/').pop());
 
-                    let demosZipPath = Path.resolve(demosZippedFullpath +`/${d.getFullYear()}-${d.getMonth()}-${d.getDate()}-${d.getHours()}-${d.getMinutes()}-${ultimoMapaNombre ?? "tfcmap"}.zip`);
+                    let demosZipPath = Path.resolve(demosZippedFullpath +`/${d.getFullYear()}-${d.getMonth()}-${d.getDate()}-${d.getHours()}-${d.getMinutes()}-${lastMapName ?? "tfcmap"}.zip`);
                     // Crea un flujo de escritura para el archivo comprimido
                     const writeStream = fs.createWriteStream(demosZipPath);
 

--- a/functions/logs/getdemos.js
+++ b/functions/logs/getdemos.js
@@ -55,14 +55,7 @@ async function getDemos() {
                     const ultimoMapaArchivo = filesToCompressFiltered[filesToCompressFiltered.length -1];
                     const ultimoMapaNombre = extraerNombreDeMapa(ultimoMapaArchivo.filePath.split('/').pop());
 
-                    let nombreDePickup = '';
-                    if(ultimoMapaNombre !== getLastPickup()){
-                        nombreDePickup = ultimoMapaNombre;
-                    } else {
-                        nombreDePickup = getLastPickup()
-                    }
-
-                    let demosZipPath = Path.resolve(demosZippedFullpath +`/${d.getFullYear()}-${d.getMonth()}-${d.getDate()}-${d.getHours()}-${d.getMinutes()}-${nombreDePickup ?? "tfcmap"}.zip`);
+                    let demosZipPath = Path.resolve(demosZippedFullpath +`/${d.getFullYear()}-${d.getMonth()}-${d.getDate()}-${d.getHours()}-${d.getMinutes()}-${ultimoMapaNombre ?? "tfcmap"}.zip`);
                     // Crea un flujo de escritura para el archivo comprimido
                     const writeStream = fs.createWriteStream(demosZipPath);
 

--- a/functions/logs/getdemos.js
+++ b/functions/logs/getdemos.js
@@ -25,9 +25,10 @@ function getLastPickup(){
     }
 }
 
-function extractMapName(filename) {
+//Extrae el nombre del mapa del nombre de un archivo .dem
+function extraerNombreDeMapa(nombrearchivo) {
     const regex = /LATAM-\d+-([\w-]+)\.dem/;
-    const match = filename.match(regex);
+    const match = nombrearchivo.match(regex);
     if (match) {
       return match[1];
     }
@@ -52,7 +53,7 @@ async function getDemos() {
                         throw new Error('There were no files beyond 10MB Size.');
                     }
                     const ultimoMapaArchivo = filesToCompressFiltered[filesToCompressFiltered.length -1];
-                    const ultimoMapaNombre = extractMapName(ultimoMapaArchivo.filePath.split('/').pop());
+                    const ultimoMapaNombre = extraerNombreDeMapa(ultimoMapaArchivo.filePath.split('/').pop());
 
                     let nombreDePickup = '';
                     if(ultimoMapaNombre !== getLastPickup()){

--- a/functions/logs/getdemos.js
+++ b/functions/logs/getdemos.js
@@ -25,6 +25,15 @@ function getLastPickup(){
     }
 }
 
+function extractMapName(filename) {
+    const regex = /LATAM-\d+-([\w-]+)\.dem/;
+    const match = filename.match(regex);
+    if (match) {
+      return match[1];
+    }
+    return null;
+  }
+
 // Función para comprimir los archivos que pesan más de 10 MB
 async function getDemos() {
     return readdirAsync(demosFullPath)
@@ -42,7 +51,17 @@ async function getDemos() {
                     if (filesToCompressFiltered.length === 0) {
                         throw new Error('There were no files beyond 10MB Size.');
                     }
-                    let demosZipPath = Path.resolve(demosZippedFullpath +`/${d.getFullYear()}-${d.getMonth()}-${d.getDate()}-${d.getHours()}-${d.getMinutes()}-${getLastPickup() ?? "tfcmap"}.zip`);
+                    const ultimoMapaArchivo = filesToCompressFiltered[filesToCompressFiltered.length -1];
+                    const ultimoMapaNombre = extractMapName(ultimoMapaArchivo.filePath.split('/').pop());
+
+                    let nombreDePickup = '';
+                    if(ultimoMapaNombre !== getLastPickup()){
+                        nombreDePickup = ultimoMapaNombre;
+                    } else {
+                        nombreDePickup = getLastPickup()
+                    }
+
+                    let demosZipPath = Path.resolve(demosZippedFullpath +`/${d.getFullYear()}-${d.getMonth()}-${d.getDate()}-${d.getHours()}-${d.getMinutes()}-${nombreDePickup ?? "tfcmap"}.zip`);
                     // Crea un flujo de escritura para el archivo comprimido
                     const writeStream = fs.createWriteStream(demosZipPath);
 


### PR DESCRIPTION
Directly, instead of taking the name of the map from the discord bot vote, I took it from the demo files that the zip has since sometimes a map different from the one voted for is played and then it ends up with another name. Then we make sure that the .dem maps in the zip match the name of the zip.